### PR TITLE
Replaced cache clean on startup with cache verify per npm5

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FCC Contour API - Node.js",
   "main": "app.js",
   "scripts": {
-    "start": "npm cache clean && npm install && node app.js",
+    "start": "npm cache verify && npm install && node app.js",
     "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha ./test/**/test-*.js || exit 0"
   },
   "repository": {


### PR DESCRIPTION
NPM log

> npm ERR! As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead. On the other hand, if you're debugging an issue with the installer, you can use `npm install --cache /tmp/empty-cache` to use a temporary cache instead of nuking the actual one.