### PR TITLE
added error handling to .env file

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,8 +22,11 @@ var helmet = require('helmet');
 var bodyparser = require('body-parser');
 var package_json = require('./package.json');
 
-var dotenv = require('dotenv');
-dotenv.load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 
 var contour = require('./controllers/contour.js');
 var elevation = require('./controllers/elevation.js');

--- a/controllers/amPattern.js
+++ b/controllers/amPattern.js
@@ -11,7 +11,12 @@ var population = require('./population.js');
 var db_lms = require('./db_lms.js');
 var db_contour = require('./db_contour.js');
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
+
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.PORT;
 var host =  process.env.HOST;

--- a/controllers/amr.js
+++ b/controllers/amr.js
@@ -1,4 +1,11 @@
-var dotenv = require('dotenv').load();
+'use strict';
+
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
+
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.PORT;
 var host =  process.env.HOST;

--- a/controllers/antenna.js
+++ b/controllers/antenna.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var LMS_SCHEMA = 'mass_media';
 var db_lms = require('./db_lms.js');
 

--- a/controllers/area.js
+++ b/controllers/area.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var CONTOURS_PG = process.env.CONTOURS_PG;
 var CONTOURS_SCHEMA = process.env.CONTOURS_SCHEMA;
 

--- a/controllers/conductivity.js
+++ b/controllers/conductivity.js
@@ -4,7 +4,11 @@
 'use strict';
 
 // **********************************************************
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var CONTOURS_PG = process.env.CONTOURS_PG;
 var CONTOURS_SCHEMA = process.env.CONTOURS_SCHEMA;
 

--- a/controllers/contour.js
+++ b/controllers/contour.js
@@ -6,7 +6,11 @@
 // **********************************************************
 
 //var configEnv = require('../config/env.json');
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.NODE_PORT;
 var host =  process.env.HOST;

--- a/controllers/contours.js
+++ b/controllers/contours.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.PORT;
 var host =  process.env.HOST;

--- a/controllers/db_contour.js
+++ b/controllers/db_contour.js
@@ -1,6 +1,10 @@
+'use strict';
 
-var dotenv = require('dotenv');
-dotenv.load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 
 var CONTOURS_PG = process.env.CONTOURS_PG;
 

--- a/controllers/db_diagnostics.js
+++ b/controllers/db_diagnostics.js
@@ -3,8 +3,12 @@
 const os = require('os');
 const fs = require('fs');
 const monitor = require('pg-monitor');
-const dotenv = require('dotenv');
-dotenv.config();
+
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 
 monitor.setTheme('matrix');
 

--- a/controllers/db_lms.js
+++ b/controllers/db_lms.js
@@ -1,6 +1,10 @@
+'use strict';
 
-const dotenv = require('dotenv');
-dotenv.load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 const promise = require('bluebird');
 
 const LMS_PG = process.env.LMS_PG;

--- a/controllers/elevation.js
+++ b/controllers/elevation.js
@@ -6,7 +6,11 @@
 // **********************************************************
 
 //var configEnv = require('../config/env.json');
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 
 var http = require('http');
 

--- a/controllers/entity.js
+++ b/controllers/entity.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.PORT;
 var host =  process.env.HOST;

--- a/controllers/haat.js
+++ b/controllers/haat.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.NODE_PORT;
 var host =  process.env.HOST;

--- a/controllers/overlap.js
+++ b/controllers/overlap.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var dotenv = require('dotenv');
-dotenv.load();
-
 var constants = require('./constants.js');
 var haat = require('./haat.js');
 var profile = require('./profile.js');

--- a/controllers/population.js
+++ b/controllers/population.js
@@ -4,7 +4,11 @@
 'use strict';
 
 // **********************************************************
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var CONTOURS_PG = process.env.CONTOURS_PG;
 var CONTOURS_SCHEMA = process.env.CONTOURS_SCHEMA;
 

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.NODE_PORT;
 var host =  process.env.HOST;

--- a/controllers/station.js
+++ b/controllers/station.js
@@ -5,7 +5,11 @@
 
 // **********************************************************
 
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var NODE_PORT =  process.env.NODE_PORT;
 var host =  process.env.HOST;

--- a/controllers/utility.js
+++ b/controllers/utility.js
@@ -1,4 +1,8 @@
-var dotenv = require('dotenv').load();
+try {
+    require('dotenv').load();
+} catch(e) {
+    console.log('error trying to load env file, app is probably running in AWS.');
+}
 var NODE_ENV = process.env.NODE_ENV;
 var ned_1_files = require('../data/ned_1_files.json');
 var ned_2_files = require('../data/ned_2_files.json');


### PR DESCRIPTION
If the .env file is not present (as is the case where we use host-defined environmental variables), the app was filling the logs with file not found errors. 